### PR TITLE
feat: Add GitHub OAuth authentication

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -6,5 +6,16 @@ SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
 # Anthropic Claude AI
 ANTHROPIC_API_KEY=your_anthropic_api_key
 
-# Optional: For Google OAuth
+# Optional: OAuth Providers
 # Configure these in your Supabase dashboard under Authentication > Providers
+
+# For Google OAuth:
+# 1. Enable Google provider in Supabase
+# 2. Add your Google OAuth credentials (Client ID & Secret)
+# 3. Set authorized redirect URI in Google Cloud Console
+
+# For GitHub OAuth:
+# 1. Enable GitHub provider in Supabase
+# 2. Create GitHub OAuth App: https://github.com/settings/applications/new
+# 3. Add Client ID & Secret to Supabase
+# 4. Set Authorization callback URL to: https://<project-ref>.supabase.co/auth/v1/callback

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## ✨ Features
 
 ### Core Infrastructure
-- 🔐 **Authentication System** - Complete auth flow with email/password + Google OAuth
+- 🔐 **Authentication System** - Complete auth flow with email/password + Google/GitHub OAuth
 - 🤖 **AI Integration** - Claude API with streaming responses and function calling
 - 🎨 **Component Library** - 10+ shadcn/ui components with dark mode support
 - 📊 **Dashboard Template** - Protected routes with responsive sidebar navigation
@@ -49,7 +49,12 @@ cp .env.local.example .env.local
 
 1. Create a new project at [supabase.com](https://supabase.com)
 2. Go to **Settings → API** to get your keys
-3. Enable Google OAuth in **Authentication → Providers** (optional)
+3. Configure OAuth providers (optional):
+   - **Google OAuth**: Enable in **Authentication → Providers**
+   - **GitHub OAuth**: 
+     - Enable in **Authentication → Providers**
+     - Create OAuth App at [github.com/settings/applications/new](https://github.com/settings/applications/new)
+     - Set callback URL: `https://YOUR_PROJECT.supabase.co/auth/v1/callback`
 4. Run the database migrations (see Database Setup below)
 
 ### 3. Configure Environment
@@ -79,8 +84,10 @@ Open [http://localhost:3000](http://localhost:3000) 🎉
 hackathon-template/
 ├── app/
 │   ├── (auth)/               # Authentication pages
-│   │   ├── login/           # Login page with OAuth
-│   │   └── signup/          # Signup with validation
+│   │   ├── login/           # Login page with OAuth (Google/GitHub)
+│   │   ├── signup/          # Signup with validation
+│   │   ├── forgot-password/ # Password reset request
+│   │   └── reset-password/  # Set new password
 │   ├── (dashboard)/          # Protected dashboard area
 │   │   └── dashboard/
 │   │       ├── layout.tsx   # Sidebar navigation

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -59,6 +59,25 @@ export default function LoginPage() {
     }
   }
 
+  const handleGithubLogin = async () => {
+    setLoading(true)
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: 'github',
+      options: {
+        redirectTo: `${location.origin}/auth/callback`,
+      },
+    })
+
+    if (error) {
+      toast({
+        title: "Error",
+        description: error.message,
+        variant: "destructive",
+      })
+      setLoading(false)
+    }
+  }
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-primary/20 via-background to-secondary/20">
       <Card className="w-full max-w-md">
@@ -149,6 +168,18 @@ export default function LoginPage() {
                 />
               </svg>
               Google
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full"
+              onClick={handleGithubLogin}
+              disabled={loading}
+            >
+              <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+              </svg>
+              GitHub
             </Button>
             <p className="text-center text-sm text-muted-foreground">
               Don't have an account?{" "}

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -77,6 +77,25 @@ export default function SignupPage() {
     }
   }
 
+  const handleGithubSignup = async () => {
+    setLoading(true)
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: 'github',
+      options: {
+        redirectTo: `${location.origin}/auth/callback`,
+      },
+    })
+
+    if (error) {
+      toast({
+        title: "Error",
+        description: error.message,
+        variant: "destructive",
+      })
+      setLoading(false)
+    }
+  }
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-primary/20 via-background to-secondary/20">
       <Card className="w-full max-w-md">
@@ -172,6 +191,18 @@ export default function SignupPage() {
                 />
               </svg>
               Google
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full"
+              onClick={handleGithubSignup}
+              disabled={loading}
+            >
+              <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+              </svg>
+              GitHub
             </Button>
             <p className="text-center text-sm text-muted-foreground">
               Already have an account?{" "}


### PR DESCRIPTION
## Summary
- Added GitHub as an additional OAuth provider alongside Google
- Users can now sign in/sign up using their GitHub accounts

## Changes
- **Login/Signup pages**: Added GitHub OAuth buttons with proper GitHub icon
- **OAuth handlers**: Implemented GitHub authentication flow using Supabase
- **Documentation**: Updated setup instructions for configuring GitHub OAuth

## Configuration Required
To enable GitHub authentication:
1. Enable GitHub provider in Supabase Dashboard (Authentication → Providers)
2. Create GitHub OAuth App at https://github.com/settings/applications/new
3. Add Client ID & Secret to Supabase
4. Set Authorization callback URL to: `https://<project-ref>.supabase.co/auth/v1/callback`

## Testing
- [ ] GitHub login works correctly
- [ ] GitHub signup works correctly
- [ ] Redirect to dashboard after successful auth
- [ ] Error handling displays appropriate messages