### PR TITLE
feat: Remove Google OAuth, keep GitHub as sole OAuth provider

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -6,16 +6,9 @@ SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
 # Anthropic Claude AI
 ANTHROPIC_API_KEY=your_anthropic_api_key
 
-# Optional: OAuth Providers
-# Configure these in your Supabase dashboard under Authentication > Providers
-
-# For Google OAuth:
-# 1. Enable Google provider in Supabase
-# 2. Add your Google OAuth credentials (Client ID & Secret)
-# 3. Set authorized redirect URI in Google Cloud Console
-
-# For GitHub OAuth:
-# 1. Enable GitHub provider in Supabase
+# Optional: GitHub OAuth
+# Configure GitHub authentication in your Supabase dashboard:
+# 1. Enable GitHub provider in Authentication > Providers
 # 2. Create GitHub OAuth App: https://github.com/settings/applications/new
 # 3. Add Client ID & Secret to Supabase
 # 4. Set Authorization callback URL to: https://<project-ref>.supabase.co/auth/v1/callback

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,167 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Next.js 15 hackathon template with Supabase authentication, AI integration (Claude API), and shadcn/ui components. Built for rapid prototyping with TypeScript, Tailwind CSS, and production-ready infrastructure.
+
+## Development Commands
+
+```bash
+# Development
+npm run dev          # Start development server on http://localhost:3000
+npm run build        # Build for production
+npm run start        # Start production server
+npm run lint         # Run ESLint
+
+# Component management
+npm run ui-add       # Add new shadcn/ui components
+
+# Quick deployment
+npm run deploy       # Git add, commit, push (for auto-deploy)
+```
+
+## Architecture
+
+### Tech Stack
+- **Framework**: Next.js 15 with App Router
+- **Language**: TypeScript with strict mode
+- **Styling**: Tailwind CSS with CSS variables for theming
+- **Auth**: Supabase Auth with email/password and GitHub OAuth
+- **Database**: Supabase (PostgreSQL with Row Level Security)
+- **AI**: Anthropic Claude API with streaming responses
+- **Components**: shadcn/ui component library
+- **State Management**: React hooks with Supabase real-time subscriptions
+
+### Directory Structure
+- `app/` - Next.js app router pages and API routes
+  - `(auth)/` - Public authentication pages (login, signup, forgot-password, reset-password)
+  - `(dashboard)/` - Protected dashboard area with sidebar layout
+  - `api/ai/` - Claude AI endpoint with streaming support
+  - `auth/callback/` - OAuth callback handler
+- `components/` - React components
+  - `ui/` - shadcn/ui components (pre-installed)
+  - `auth-button.tsx` - Dynamic auth state button
+  - `providers.tsx` - Theme and toast providers
+- `hooks/` - Custom React hooks
+  - `use-user.tsx` - Auth state management
+  - `use-toast.ts` - Toast notifications
+- `lib/` - Utility functions and configurations
+  - `supabase/` - Supabase client configurations (client, server, middleware)
+  - `utils.ts` - Helper functions including `cn()` for class names
+
+### Key Patterns
+
+#### Authentication Flow
+- Middleware (`middleware.ts`) handles session refresh on all routes
+- Server components use `createClient()` from `lib/supabase/server.ts`
+- Client components use `createClient()` from `lib/supabase/client.ts`
+- Protected routes check auth in server components and redirect if not authenticated
+- `useUser()` hook provides auth state in client components
+
+#### Database Access
+- All database operations go through Supabase client
+- Row Level Security (RLS) policies enforce user-based access control
+- Real-time subscriptions available for live updates
+- TypeScript types can be generated from database schema
+
+#### AI Integration
+- `/api/ai/route.ts` handles Claude API requests
+- Supports streaming responses using Vercel AI SDK
+- Requires `ANTHROPIC_API_KEY` environment variable
+- Default model: claude-3-5-sonnet-20241022
+
+## Environment Variables
+
+Required in `.env.local`:
+```env
+# Supabase (Required)
+NEXT_PUBLIC_SUPABASE_URL=https://YOUR_PROJECT.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_key_here
+SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here
+
+# Anthropic AI (Optional - needed for AI features)
+ANTHROPIC_API_KEY=sk-ant-api03-YOUR_KEY_HERE
+
+# GitHub OAuth (Optional)
+# Configure in Supabase Dashboard under Authentication > Providers
+```
+
+## Code Conventions
+
+### Import Aliases
+- Use `@/` for absolute imports from project root
+- Example: `import { Button } from '@/components/ui/button'`
+
+### Component Patterns
+- Server Components by default (no "use client" directive)
+- Add "use client" only when needed (hooks, browser APIs, event handlers)
+- Use shadcn/ui components from `@/components/ui/`
+- Apply styles using Tailwind classes with `cn()` helper for conditional classes
+
+### TypeScript
+- Strict mode enabled
+- Define interfaces for component props and data structures
+- Use `type` for unions/intersections, `interface` for object shapes
+
+### Styling
+- Tailwind CSS for all styling
+- CSS variables defined in `globals.css` for theming
+- Dark mode support via `next-themes` provider
+- Use `cn()` from `lib/utils.ts` for merging class names
+
+### Database Schema
+When creating new tables:
+1. Always enable Row Level Security (RLS)
+2. Create appropriate policies for user access
+3. Use UUID for primary keys
+4. Include `created_at` and `updated_at` timestamps
+5. Reference `auth.users(id)` for user relationships
+
+## Testing Approach
+
+No test framework is currently configured. When adding tests:
+1. Check with user for preferred testing framework
+2. Common options: Jest, Vitest, or Playwright for E2E
+3. Update this section once testing is configured
+
+## Quick Reference
+
+### Add a New Page
+1. Create directory in `app/` following Next.js conventions
+2. Add `page.tsx` for the route
+3. Use server components by default
+4. Add to sidebar navigation if in dashboard area
+
+### Add Database Table
+1. Create migration in Supabase SQL editor
+2. Enable RLS and create policies
+3. Generate TypeScript types if needed
+4. Create data fetching functions
+
+### Implement Protected Route
+Server component:
+```tsx
+import { createClient } from '@/lib/supabase/server'
+import { redirect } from 'next/navigation'
+
+export default async function ProtectedPage() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  
+  if (!user) {
+    redirect('/login')
+  }
+  
+  // Protected content
+}
+```
+
+### Stream AI Response
+Use the existing `/api/ai` endpoint with fetch or Vercel AI SDK's `useChat` hook.
+
+## Additional Resources
+
+- `speed-snippets.md` - Copy-paste code patterns for common features
+- `README.md` - Detailed setup instructions and deployment guide

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## ✨ Features
 
 ### Core Infrastructure
-- 🔐 **Authentication System** - Complete auth flow with email/password + Google/GitHub OAuth
+- 🔐 **Authentication System** - Complete auth flow with email/password + GitHub OAuth
 - 🤖 **AI Integration** - Claude API with streaming responses and function calling
 - 🎨 **Component Library** - 10+ shadcn/ui components with dark mode support
 - 📊 **Dashboard Template** - Protected routes with responsive sidebar navigation
@@ -49,12 +49,11 @@ cp .env.local.example .env.local
 
 1. Create a new project at [supabase.com](https://supabase.com)
 2. Go to **Settings → API** to get your keys
-3. Configure OAuth providers (optional):
-   - **Google OAuth**: Enable in **Authentication → Providers**
-   - **GitHub OAuth**: 
-     - Enable in **Authentication → Providers**
-     - Create OAuth App at [github.com/settings/applications/new](https://github.com/settings/applications/new)
-     - Set callback URL: `https://YOUR_PROJECT.supabase.co/auth/v1/callback`
+3. Configure GitHub OAuth (optional):
+   - Enable GitHub in **Authentication → Providers**
+   - Create OAuth App at [github.com/settings/applications/new](https://github.com/settings/applications/new)
+   - Add Client ID & Secret to Supabase
+   - Set callback URL: `https://YOUR_PROJECT.supabase.co/auth/v1/callback`
 4. Run the database migrations (see Database Setup below)
 
 ### 3. Configure Environment
@@ -84,7 +83,7 @@ Open [http://localhost:3000](http://localhost:3000) 🎉
 hackathon-template/
 ├── app/
 │   ├── (auth)/               # Authentication pages
-│   │   ├── login/           # Login page with OAuth (Google/GitHub)
+│   │   ├── login/           # Login page with GitHub OAuth
 │   │   ├── signup/          # Signup with validation
 │   │   ├── forgot-password/ # Password reset request
 │   │   └── reset-password/  # Set new password

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -40,25 +40,6 @@ export default function LoginPage() {
     }
   }
 
-  const handleGoogleLogin = async () => {
-    setLoading(true)
-    const { error } = await supabase.auth.signInWithOAuth({
-      provider: 'google',
-      options: {
-        redirectTo: `${location.origin}/auth/callback`,
-      },
-    })
-
-    if (error) {
-      toast({
-        title: "Error",
-        description: error.message,
-        variant: "destructive",
-      })
-      setLoading(false)
-    }
-  }
-
   const handleGithubLogin = async () => {
     setLoading(true)
     const { error } = await supabase.auth.signInWithOAuth({
@@ -142,33 +123,6 @@ export default function LoginPage() {
                 </span>
               </div>
             </div>
-            <Button
-              type="button"
-              variant="outline"
-              className="w-full"
-              onClick={handleGoogleLogin}
-              disabled={loading}
-            >
-              <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
-                <path
-                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-                  fill="#4285F4"
-                />
-                <path
-                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                  fill="#34A853"
-                />
-                <path
-                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                  fill="#FBBC05"
-                />
-                <path
-                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                  fill="#EA4335"
-                />
-              </svg>
-              Google
-            </Button>
             <Button
               type="button"
               variant="outline"

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -58,25 +58,6 @@ export default function SignupPage() {
     }
   }
 
-  const handleGoogleSignup = async () => {
-    setLoading(true)
-    const { error } = await supabase.auth.signInWithOAuth({
-      provider: 'google',
-      options: {
-        redirectTo: `${location.origin}/auth/callback`,
-      },
-    })
-
-    if (error) {
-      toast({
-        title: "Error",
-        description: error.message,
-        variant: "destructive",
-      })
-      setLoading(false)
-    }
-  }
-
   const handleGithubSignup = async () => {
     setLoading(true)
     const { error } = await supabase.auth.signInWithOAuth({
@@ -165,33 +146,6 @@ export default function SignupPage() {
                 </span>
               </div>
             </div>
-            <Button
-              type="button"
-              variant="outline"
-              className="w-full"
-              onClick={handleGoogleSignup}
-              disabled={loading}
-            >
-              <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
-                <path
-                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-                  fill="#4285F4"
-                />
-                <path
-                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                  fill="#34A853"
-                />
-                <path
-                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                  fill="#FBBC05"
-                />
-                <path
-                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                  fill="#EA4335"
-                />
-              </svg>
-              Google
-            </Button>
             <Button
               type="button"
               variant="outline"


### PR DESCRIPTION
## Summary
Simplified authentication by removing Google OAuth and keeping GitHub as the sole OAuth provider alongside email/password authentication.

## Motivation
- Reduce complexity and configuration overhead
- Focus on developer-centric authentication (GitHub)
- Simplify onboarding for new developers
- Fewer OAuth providers to maintain and configure

## Changes
- **Login/Signup Pages**: Removed Google OAuth handlers and buttons
- **Environment Configuration**: Updated `.env.local.example` to only document GitHub OAuth
- **Documentation**: Updated README.md to remove all Google OAuth references
- **Development Docs**: Added CLAUDE.md with current authentication setup

## Breaking Changes
⚠️ **Google OAuth has been removed**. Users who previously authenticated with Google will need to:
- Use GitHub OAuth instead, or
- Use email/password authentication

## Testing
- [ ] GitHub login works correctly
- [ ] GitHub signup works correctly  
- [ ] Email/password authentication still works
- [ ] No Google buttons appear in UI
- [ ] Documentation accurately reflects available auth methods

## Migration Notes
For existing deployments:
1. Disable Google provider in Supabase Dashboard
2. Update any user communication about available auth methods
3. Consider migrating existing Google OAuth users if needed