### PR TITLE
fix: Remove user ID display from dropdown menu

### DIFF
--- a/components/auth-button.tsx
+++ b/components/auth-button.tsx
@@ -55,9 +55,6 @@ export function AuthButton() {
         <DropdownMenuLabel className="font-normal">
           <div className="flex flex-col space-y-1">
             <p className="text-sm font-medium leading-none">{user.email}</p>
-            <p className="text-xs leading-none text-muted-foreground">
-              {user.id}
-            </p>
           </div>
         </DropdownMenuLabel>
         <DropdownMenuSeparator />


### PR DESCRIPTION
## Summary
Removes the user ID display from the user dropdown menu in the dashboard, showing only the user's email address for a cleaner, more professional interface.

## Problem
The user dropdown was displaying the raw user ID below the email address, which:
- Looked unprofessional
- Confused users with technical information
- Added no value to the user experience

## Solution
- Removed the user ID display from the dropdown menu
- Kept only the email address as the user identifier
- Maintained all menu functionality (Dashboard, Settings, Sign out)

## Changes
- **components/auth-button.tsx**: Removed lines displaying `user.id`

## Testing
- [ ] Dropdown menu displays correctly with only email
- [ ] All menu items still function (Dashboard, Settings, Sign out)
- [ ] No layout issues or spacing problems
- [ ] Works on both desktop and mobile views

## Screenshots
Before: Email + User ID displayed
After: Only email displayed (cleaner UI)